### PR TITLE
Fix for JavaScript error in client search for unmanaged clients.

### DIFF
--- a/templates/clients/list.html
+++ b/templates/clients/list.html
@@ -69,7 +69,7 @@
         function refresh_search() {
             function parse_tds(tds) {
                 return {
-                    long_name: tds[0].firstElementChild.innerText,
+                    long_name: tds[0].innerText,
                     creator_name: tds[1].textContent
                 };
             }


### PR DESCRIPTION
The searching functionality is broken when there is at least one unmanaged client in the list. This is for the absence of the <a> child in the <td>. The property innerText is recursive, so it is not necessary to search for the firstElementChild.